### PR TITLE
Offer active configuration to useLink

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -148,23 +148,33 @@ export const createRouter = <
     return route ? JSON.parse(route) : route;
   };
 
+  type CompareHrefUrl = { href: string; currentLocation: string };
+  const defaultCompareUrls = ({ href, currentLocation }: CompareHrefUrl) =>
+    href === currentLocation;
+
   // Kudos to https://github.com/remix-run/react-router/pull/7998
   const useLink = ({
     href,
     replace = false,
     target,
+    compareUrls = defaultCompareUrls,
   }: {
     href: string;
     replace?: boolean | undefined;
     target?: React.HTMLAttributeAnchorTarget | undefined;
+    compareUrls?: (params: CompareHrefUrl) => boolean;
   }) => {
     const active = useSubscription(
       React.useMemo(
         () => ({
-          getCurrentValue: () => href === getCurrentLocation().url,
+          getCurrentValue: () =>
+            compareUrls({
+              href,
+              currentLocation: getCurrentLocation().url,
+            }),
           subscribe,
         }),
-        [href],
+        [href, compareUrls],
       ),
     );
 


### PR DESCRIPTION
# Summary

Currently, the algorithm responsive for setting `active` on `useLink` is a black box. This might not suit every need (e.g. changing a query-string shouldn't make a section link inactive).

Due to the optimisation of computing `useSubscription` to avoid unnecessary re-rerenders, having this comparison function as a prop seems like the most reasonable way to expose this feature.
