### PR TITLE
Replace finite with isArea in matchers

### DIFF
--- a/__tests__/matcher.ts
+++ b/__tests__/matcher.ts
@@ -17,7 +17,7 @@ const matchEqual = <E>(path: string, expected: E) =>
 
 test("getMatcher returns a proper matcher structure for paths without params", () => {
   getMatcherEqual("Groups", "/groups", {
-    finite: true,
+    isArea: false,
     ranking: 7,
     path: ["groups"],
     search: {},
@@ -25,7 +25,7 @@ test("getMatcher returns a proper matcher structure for paths without params", (
   });
 
   getMatcherEqual("MyGroup", "/groups/mine", {
-    finite: true,
+    isArea: false,
     ranking: 14,
     path: ["groups", "mine"],
     search: {},
@@ -35,7 +35,7 @@ test("getMatcher returns a proper matcher structure for paths without params", (
 
 test("getMatcher returns a proper matcher structure for paths with params (in path only)", () => {
   getMatcherEqual("Group", "/group/:groupId", {
-    finite: true,
+    isArea: false,
     ranking: 13,
     path: ["group", { name: "groupId" }],
     search: {},
@@ -43,7 +43,7 @@ test("getMatcher returns a proper matcher structure for paths with params (in pa
   });
 
   getMatcherEqual("Users", "/groups/:groupId/users", {
-    finite: true,
+    isArea: false,
     ranking: 20,
     path: ["groups", { name: "groupId" }, "users"],
     search: {},
@@ -53,7 +53,7 @@ test("getMatcher returns a proper matcher structure for paths with params (in pa
 
 test("getMatcher returns a proper matcher structure for paths with params (in path, search and hash)", () => {
   getMatcherEqual("Group", "/group/:groupId?:foo&:bar[]#:baz", {
-    finite: true,
+    isArea: false,
     ranking: 13,
     path: ["group", { name: "groupId" }],
     search: { foo: "unique", bar: "multiple" },
@@ -61,9 +61,9 @@ test("getMatcher returns a proper matcher structure for paths with params (in pa
   });
 });
 
-test("getMatcher decrements the ranking by 1 if the path is not finite", () => {
+test("getMatcher decrements the ranking by 1 if the path is an area", () => {
   getMatcherEqual("UsersArea", "/groups/:groupId/users/*", {
-    finite: false,
+    isArea: true,
     ranking: 19,
     path: ["groups", { name: "groupId" }, "users"],
     search: {},
@@ -71,7 +71,7 @@ test("getMatcher decrements the ranking by 1 if the path is not finite", () => {
   });
 
   getMatcherEqual("Users", "/groups/:groupId/users", {
-    finite: true,
+    isArea: false,
     ranking: 20,
     path: ["groups", { name: "groupId" }, "users"],
     search: {},

--- a/src/createRouter.ts
+++ b/src/createRouter.ts
@@ -6,7 +6,7 @@ import { getLocation, history, subscribeToLocation } from "./history";
 import { getMatcher, match, matchToHistoryPath } from "./matcher";
 import {
   ExtractRoutesParams,
-  GetNestedRoutes,
+  GetAreaRoutes,
   Matcher,
   Params,
   ParamsArg,
@@ -24,11 +24,11 @@ export const createRouter = <
   } = {},
 ) => {
   type RoutesWithBasePath = PrependBasePath<Routes, BasePath>;
-  type NestedRoutes = GetNestedRoutes<RoutesWithBasePath>;
-  type NestedRoutesParams = ExtractRoutesParams<NestedRoutes>;
-  type FiniteRoutes = Omit<RoutesWithBasePath, keyof NestedRoutes>;
+  type AreaRoutes = GetAreaRoutes<RoutesWithBasePath>;
+  type AreaRoutesParams = ExtractRoutesParams<AreaRoutes>;
+  type FiniteRoutes = Omit<RoutesWithBasePath, keyof AreaRoutes>;
   type FiniteRoutesParams = ExtractRoutesParams<FiniteRoutes>;
-  type RoutesParams = NestedRoutesParams & FiniteRoutesParams;
+  type RoutesParams = AreaRoutesParams & FiniteRoutesParams;
 
   const { basePath = "" } = options;
 
@@ -60,7 +60,7 @@ export const createRouter = <
   for (let index = 0; index < rankedMatchers.length; index++) {
     const matcher = rankedMatchers[index];
 
-    if (matcher?.finite) {
+    if (matcher != null && !matcher.isArea) {
       const routeName = matcher.name as keyof FiniteRoutes;
 
       createURLFunctions[routeName] = (params?: Params) =>
@@ -68,7 +68,7 @@ export const createRouter = <
     }
   }
 
-  const useRoute = <RouteName extends keyof FiniteRoutes | keyof NestedRoutes>(
+  const useRoute = <RouteName extends keyof FiniteRoutes | keyof AreaRoutes>(
     routeNames: ReadonlyArray<RouteName>,
   ): RouteName extends string
     ?

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -25,7 +25,7 @@ export const getMatcher = (name: string, route: string): Matcher => {
     const { ranking, path } = extractFromPathname(pathname);
 
     return {
-      finite: false,
+      isArea: true,
       name,
       ranking: ranking - 1, // penality due to wildcard
       path,
@@ -48,7 +48,7 @@ export const getMatcher = (name: string, route: string): Matcher => {
     }
 
     return {
-      finite: true,
+      isArea: false,
       name,
       ranking,
       path,
@@ -63,11 +63,11 @@ export const extractLocationParams = (
   matcher: Matcher,
 ): Params | undefined => {
   const { path: locationPath } = location;
-  const { finite, path: matcherPath } = matcher;
+  const { isArea, path: matcherPath } = matcher;
 
   if (
-    (finite && locationPath.length !== matcherPath.length) ||
-    (!finite && locationPath.length < matcherPath.length)
+    (!isArea && locationPath.length !== matcherPath.length) ||
+    (isArea && locationPath.length < matcherPath.length)
   ) {
     return;
   }
@@ -98,8 +98,8 @@ export const extractLocationParams = (
     }
   }
 
-  if (!finite) {
-    return params; // don't extract search and hash on non-finite routes
+  if (isArea) {
+    return params; // don't extract area search and hash
   }
 
   for (const key in matcher.search) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,12 +3,13 @@ export type Params = Record<string, string | string[] | undefined>;
 export type Subscription = (location: Location) => void;
 
 export type Matcher = {
+  isArea: boolean;
   name: string;
+  ranking: number;
+
   path: (string | { name: string })[];
   search: Record<string, "unique" | "multiple">;
   hash: string | undefined;
-  finite: boolean;
-  ranking: number;
 };
 
 export type Location = Readonly<{
@@ -95,7 +96,7 @@ export type PrependBasePath<
   [K in keyof Routes]: ConcatPaths<BasePath, Routes[K]>;
 };
 
-export type GetNestedRoutes<Routes extends Record<string, string>> = {
+export type GetAreaRoutes<Routes extends Record<string, string>> = {
   [K in keyof Routes as Routes[K] extends `${infer _}*`
     ? K
     : never]: Routes[K] extends `${infer Rest}*` ? Rest : never;


### PR DESCRIPTION
As part of the `Matcher` type will be exposed as return type of `createGroup` in a future version, I want to reduce the lib exposed glossary. `Area` is already used in our example, it seems fine to me.