### PR TITLE
Expose router-path

### DIFF
--- a/__tests__/path.ts
+++ b/__tests__/path.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "vitest";
+import { createGroup, createRouter } from "../src";
+
+const Router = createRouter({
+  Home: "/",
+  Users: "/users",
+  User: "/users/:userId",
+
+  ...createGroup("Repository", "/:repositoryName", {
+    List: "/",
+    Issues: "/issues",
+    Pulls: "/pulls",
+    Actions: "/actions",
+    Projects: "/projects",
+    Security: "/security",
+
+    ...createGroup("Settings", "/settings", {
+      List: "/",
+      Collaborators: "/access",
+      Branches: "/branches",
+      Actions: "/actions",
+      Webhooks: "/hooks",
+      Pages: "/pages",
+      SecurityAnalysis: "/security_analysis",
+      DeployKeys: "/keys",
+      Secrets: "/secrets",
+    }),
+  }),
+});
+
+test.each([
+  ["Home", "/"],
+  ["Users", "/users"],
+  ["User", "/users/:userId"],
+  ["RepositoryList", "/:repositoryName"],
+  ["RepositoryIssues", "/:repositoryName/issues"],
+  ["RepositoryPulls", "/:repositoryName/pulls"],
+  ["RepositoryActions", "/:repositoryName/actions"],
+  ["RepositoryProjects", "/:repositoryName/projects"],
+  ["RepositorySecurity", "/:repositoryName/security"],
+  ["RepositorySettingsList", "/:repositoryName/settings"],
+  ["RepositorySettingsCollaborators", "/:repositoryName/settings/access"],
+  ["RepositorySettingsBranches", "/:repositoryName/settings/branches"],
+  ["RepositorySettingsActions", "/:repositoryName/settings/actions"],
+  ["RepositorySettingsWebhooks", "/:repositoryName/settings/hooks"],
+  ["RepositorySettingsPages", "/:repositoryName/settings/pages"],
+  [
+    "RepositorySettingsSecurityAnalysis",
+    "/:repositoryName/settings/security_analysis",
+  ],
+  ["RepositorySettingsDeployKeys", "/:repositoryName/settings/keys"],
+  ["RepositorySettingsSecrets", "/:repositoryName/settings/secrets"],
+])(
+  "Router.path.$name from original definition should pass forward $providedPath",
+  (name, providedPath) => {
+    expect(Router[name].path).toEqual(providedPath);
+  },
+);

--- a/docs/docs/router.md
+++ b/docs/docs/router.md
@@ -55,3 +55,12 @@ Takes a route name and its associated params and navigates to it **without** cre
 Router.replace("Home");
 Router.replace("UserDetail", { userId: "123" });
 ```
+
+## Router.{RouteName}.path
+
+Provides the original string path passed to `createRouter` for the route name. Useful when the whole path must be passed to other routers like React Router
+
+```ts
+Router.UserList.path; // "/users"
+Router.UserDetail.path; // "/user/:userId"
+```


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

I wanted quick access to the originally-specified path string, to insert them into the correct place in my react-router routes.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

Added test proving that `.path` is passed through exactly as specified in the initial configuration.

<!-- Demonstrate the code is solid. -->

### What's required for testing (prerequisites)?

N/A

### What are the steps to reproduce (after prerequisites)?

N/A

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I added the documentation in `README.md`
- [ ] I added a sample use of the API in the example project (`example/`)
