### PR TITLE
Fix params type when the route name is an union

### DIFF
--- a/docs/docs/utility-types.md
+++ b/docs/docs/utility-types.md
@@ -1,0 +1,21 @@
+---
+title: Utility types
+sidebar_label: Utility types
+---
+
+To easily extract routes types, use `InferRoutes`:
+
+```tsx {1,9}
+import { createRouter, InferRoutes } from "@swan-io/chicane";
+
+export const Router = createRouter({
+  UserList: "/users",
+  UserDetail: "/users/:userId",
+});
+
+// A map of RouteName and its associated RouteParams
+type Routes = InferRoutes<typeof Router>;
+
+export type RouteName = keyof Routes;
+export type RouteParams<T extends RouteName> = Routes[T];
+```

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -27,6 +27,7 @@ const sidebars = {
         "route-pattern-syntax",
         "matching-some-routes",
         "linking-to-a-route",
+        "utility-types",
         "server-side-rendering",
       ],
     },

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -27,8 +27,8 @@ const sidebars = {
         "route-pattern-syntax",
         "matching-some-routes",
         "linking-to-a-route",
-        "utility-types",
         "server-side-rendering",
+        "utility-types",
       ],
     },
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/chicane",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "description": "A simple and safe router for React and TypeScript",
   "author": "Mathieu Acthernoene <mathieu.acthernoene@swan.io>",

--- a/src/createRouter.ts
+++ b/src/createRouter.ts
@@ -22,6 +22,7 @@ import {
   ParseRoutes,
   PrependBasePath,
   RouteObject,
+  UnionToIntersection,
 } from "./types";
 
 export const createRouter = <
@@ -138,12 +139,12 @@ export const createRouter = <
 
   const push = <RouteName extends keyof FiniteRoutes>(
     routeName: RouteName,
-    ...params: ParamsArg<FiniteRoutesParams[RouteName]>
+    ...params: ParamsArg<UnionToIntersection<FiniteRoutesParams[RouteName]>>
   ): void => pushUnsafe(matchToUrl(matchers[routeName], first(params)));
 
   const replace = <RouteName extends keyof FiniteRoutes>(
     routeName: RouteName,
-    ...params: ParamsArg<FiniteRoutesParams[RouteName]>
+    ...params: ParamsArg<UnionToIntersection<FiniteRoutesParams[RouteName]>>
   ): void => replaceUnsafe(matchToUrl(matchers[routeName], first(params)));
 
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export {
 } from "./history";
 export { decodeSearch, encodeSearch } from "./search";
 export { ServerUrlProvider } from "./server";
-export type { Location, Search } from "./types";
+export type { InferRoutes, Location, Search } from "./types";
 export { useBlocker } from "./useBlocker";
 export { useFocusReset } from "./useFocusReset";
 export { useLinkProps } from "./useLinkProps";

--- a/src/types.ts
+++ b/src/types.ts
@@ -172,10 +172,10 @@ type NonOptionalProperties<T> = Exclude<
 >;
 
 // https://github.com/microsoft/TypeScript/issues/13298#issuecomment-1610361208
-export type UnionToIntersection<U> = (
-  U extends never ? never : (arg: U) => never
-) extends (arg: infer I) => void
-  ? I
+export type UnionToIntersection<Union> = (
+  Union extends never ? never : (_: Union) => never
+) extends (_: infer Intersection) => void
+  ? Intersection
   : never;
 
 export type ParamsArg<Params> =

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,6 +171,13 @@ type NonOptionalProperties<T> = Exclude<
   undefined
 >;
 
+// https://github.com/microsoft/TypeScript/issues/13298#issuecomment-1610361208
+export type UnionToIntersection<U> = (
+  U extends never ? never : (arg: U) => never
+) extends (arg: infer I) => void
+  ? I
+  : never;
+
 export type ParamsArg<Params> =
   Params extends Record<PropertyKey, never>
     ? []
@@ -180,6 +187,6 @@ export type ParamsArg<Params> =
 
 export type GetCreateURLFns<RoutesParams extends Record<string, Params>> = {
   [RouteName in keyof RoutesParams]: (
-    ...params: ParamsArg<RoutesParams[RouteName]>
+    ...params: ParamsArg<UnionToIntersection<RoutesParams[RouteName]>>
   ) => string;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -190,3 +190,23 @@ export type GetCreateURLFns<RoutesParams extends Record<string, Params>> = {
     ...params: ParamsArg<UnionToIntersection<RoutesParams[RouteName]>>
   ) => string;
 };
+
+// User land helpers
+
+type RouteLike = {
+  name: string;
+  params: Params;
+};
+
+type RouterLike = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getRoute: (...args: any[]) => RouteLike | undefined;
+};
+
+type RemapRoute<Route extends RouteLike> = {
+  [N in Route["name"]]: Extract<Route, { name: N }>["params"];
+};
+
+export type InferRoutes<Router extends RouterLike> = RemapRoute<
+  NonNullable<ReturnType<Router["getRoute"]>>
+>;


### PR DESCRIPTION
Let's suppose you have this router:

```ts
export const Router = createRouter({
  Home: "/",
  ProjectRoot: "/projects/:projectId",

  DevelopersApi:
    "/projects/:projectId/:projectEnv{live|sandbox}/developers/api",
});

const doSomething = (name: "ProjectRoot" | "DevelopersApi") => {
  Router.push(name, { projectId: "" }); // no error before, now there's one
};
```

Before, there was no error. The route name could be either `ProjectRoot` or `DevelopersApi`, but the params was not an intersection or both those route params.